### PR TITLE
Add holder factory implementation that uses reflection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,5 +76,11 @@
 		    <scope>provided</scope>
 		    <version>${android.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.8</version>
+			<scope>test</scope>
+		</dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/madgag/android/listviews/BaseViewHolder.java
+++ b/src/main/java/com/madgag/android/listviews/BaseViewHolder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2011 Kevin Sawicki <kevinsawicki@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+package com.madgag.android.listviews;
+
+import android.view.View;
+
+/**
+ * Base view holder class
+ * 
+ * @param <T>
+ *            model class that the view is bound to
+ */
+public abstract class BaseViewHolder<T> implements ViewHolder<T> {
+
+	/**
+	 * View to fill in
+	 */
+	protected final View view;
+
+	/**
+	 * Create holder for view
+	 * 
+	 * @param view
+	 */
+	public BaseViewHolder(View view) {
+		this.view = view;
+	}
+}

--- a/src/main/java/com/madgag/android/listviews/ReflectiveHolderFactory.java
+++ b/src/main/java/com/madgag/android/listviews/ReflectiveHolderFactory.java
@@ -1,0 +1,84 @@
+package com.madgag.android.listviews;
+
+import android.view.View;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+
+/**
+ * {@link ViewHolderFactory} that uses reflection to create new
+ * {@link ViewHolder} isntances with optional parameters
+ * 
+ * @param <T>
+ *            model class that views are bound to
+ */
+public class ReflectiveHolderFactory<T> implements ViewHolderFactory<T> {
+
+	private static Constructor<?> findMatch(Class<?> clazz, Class<?>[] types) {
+		Constructor<?>[] candidates = clazz.getConstructors();
+		for (Constructor<?> candidate : candidates) {
+			Class<?>[] params = candidate.getParameterTypes();
+			if (params.length != types.length)
+				continue;
+			boolean match = true;
+			for (int i = 0; i < types.length; i++)
+				if (!params[i].isAssignableFrom(types[i])) {
+					match = false;
+					break;
+				}
+			if (match)
+				return candidate;
+		}
+		return null;
+	}
+
+	private final Constructor<? extends ViewHolder<T>> constructor;
+
+	private final Object[] args;
+
+	/**
+	 * Create holder factory for constructor and arguments
+	 * 
+	 * @param holder
+	 * @param args
+	 * @throws RuntimeException
+	 */
+	@SuppressWarnings("unchecked")
+	public ReflectiveHolderFactory(Class<? extends ViewHolder<T>> holder,
+			Object... args) {
+		if (args == null)
+			args = new Object[0];
+
+		if (holder.isMemberClass() && !Modifier.isStatic(holder.getModifiers()))
+			throw new IllegalArgumentException(
+					"Non-static member classes not supported");
+
+		Class<?>[] types = new Class[args.length + 1];
+		// First argument must be the view itself
+		types[0] = View.class;
+		for (int i = 0; i < args.length; i++)
+			types[i + 1] = args[i].getClass();
+
+		constructor = (Constructor<? extends ViewHolder<T>>) findMatch(holder,
+				types);
+		if (constructor == null)
+			throw new IllegalArgumentException(
+					"No constructor found to bind arguments to");
+		this.args = new Object[args.length + 1];
+		System.arraycopy(args, 0, this.args, 1, args.length);
+	}
+
+	public ViewHolder<T> createViewHolderFor(View view) {
+		try {
+			args[0] = view;
+			return constructor.newInstance(args);
+		} catch (InstantiationException e) {
+			throw new IllegalArgumentException(e);
+		} catch (IllegalAccessException e) {
+			throw new IllegalArgumentException(e);
+		} catch (InvocationTargetException e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+}

--- a/src/main/java/com/madgag/android/listviews/ReflectiveHolderFactory.java
+++ b/src/main/java/com/madgag/android/listviews/ReflectiveHolderFactory.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2011 Kevin Sawicki <kevinsawicki@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
 package com.madgag.android.listviews;
 
 import android.view.View;
@@ -8,14 +29,16 @@ import java.lang.reflect.Modifier;
 
 /**
  * {@link ViewHolderFactory} that uses reflection to create new
- * {@link ViewHolder} isntances with optional parameters
+ * {@link ViewHolder} instances with the given parameters that are injected into
+ * each {@link ViewHolder} created.
  * 
  * @param <T>
  *            model class that views are bound to
  */
 public class ReflectiveHolderFactory<T> implements ViewHolderFactory<T> {
 
-	private static Constructor<?> findMatch(Class<?> clazz, Class<?>[] types) {
+	private static Constructor<?> findMatch(final Class<?> clazz,
+			final Class<?>[] types) {
 		Constructor<?>[] candidates = clazz.getConstructors();
 		for (Constructor<?> candidate : candidates) {
 			Class<?>[] params = candidate.getParameterTypes();
@@ -45,7 +68,7 @@ public class ReflectiveHolderFactory<T> implements ViewHolderFactory<T> {
 	 * @throws RuntimeException
 	 */
 	@SuppressWarnings("unchecked")
-	public ReflectiveHolderFactory(Class<? extends ViewHolder<T>> holder,
+	public ReflectiveHolderFactory(final Class<? extends ViewHolder<T>> holder,
 			Object... args) {
 		if (args == null)
 			args = new Object[0];
@@ -69,7 +92,7 @@ public class ReflectiveHolderFactory<T> implements ViewHolderFactory<T> {
 		System.arraycopy(args, 0, this.args, 1, args.length);
 	}
 
-	public ViewHolder<T> createViewHolderFor(View view) {
+	public ViewHolder<T> createViewHolderFor(final View view) {
 		try {
 			args[0] = view;
 			return constructor.newInstance(args);

--- a/src/test/java/com/madgag/android/listviews/ReflectiveTest.java
+++ b/src/test/java/com/madgag/android/listviews/ReflectiveTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2011 Kevin Sawicki <kevinsawicki@gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+package com.madgag.android.listviews;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import android.view.View;
+
+import org.junit.Test;
+
+/**
+ * Unit tests of {@link ReflectiveHolderFactory}
+ */
+public class ReflectiveTest {
+
+	private static class StaticViewHolder extends BaseViewHolder<String> {
+
+		public StaticViewHolder(View view) {
+			super(view);
+		}
+
+		public void updateViewFor(String item) {
+		}
+	}
+
+	private class MemberViewHolder extends BaseViewHolder<String> {
+
+		public MemberViewHolder(View view) {
+			super(view);
+		}
+
+		public void updateViewFor(String item) {
+		}
+	}
+
+	private static class StringViewHolder extends BaseViewHolder<String> {
+
+		final String argument;
+
+		public StringViewHolder(View view, String argument) {
+			super(view);
+			this.argument = argument;
+		}
+
+		public void updateViewFor(String item) {
+		}
+	}
+
+	private static class TwoStringViewHolder extends BaseViewHolder<String> {
+
+		final String argument1;
+
+		final CharSequence argument2;
+
+		public TwoStringViewHolder(View view, String argument1,
+				CharSequence argument2) {
+			super(view);
+			this.argument1 = argument1;
+			this.argument2 = argument2;
+		}
+
+		public void updateViewFor(String item) {
+		}
+	}
+
+	/**
+	 * Create holder for class with single default constructor that takes a view
+	 */
+	@Test
+	public void defaultConstructor() {
+		ReflectiveHolderFactory<String> factory = new ReflectiveHolderFactory<String>(
+				StaticViewHolder.class, (Object[]) null);
+		ViewHolder<String> holder = factory.createViewHolderFor(null);
+		assertNotNull(holder);
+	}
+
+	/**
+	 * Create holder for non-static member class
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void defaultConstructorNonStaticMemberClass() {
+		new ReflectiveHolderFactory<String>(MemberViewHolder.class);
+	}
+
+	/**
+	 * Create holder for non-static member class
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void noConstructorMatchMissingParam() {
+		ReflectiveHolderFactory<String> factory = new ReflectiveHolderFactory<String>(
+				StringViewHolder.class);
+		factory.createViewHolderFor(null);
+	}
+
+	/**
+	 * Create holder for non-static member class
+	 */
+	@Test(expected = IllegalArgumentException.class)
+	public void noConstructorMatchInvalidParam() {
+		ReflectiveHolderFactory<String> factory = new ReflectiveHolderFactory<String>(
+				StringViewHolder.class, new Object());
+		factory.createViewHolderFor(null);
+	}
+
+	/**
+	 * Create holder for class that takes a String constructor argument
+	 */
+	@Test
+	public void constructorWithSingleArgument() {
+		ReflectiveHolderFactory<String> factory = new ReflectiveHolderFactory<String>(
+				StringViewHolder.class, "abcd");
+		ViewHolder<String> holder = factory.createViewHolderFor(null);
+		assertNotNull(holder);
+		assertEquals("abcd", ((StringViewHolder) holder).argument);
+	}
+
+	/**
+	 * Create holder for class that takes a String and CharSequence constructor
+	 * argument
+	 */
+	@Test
+	public void constructorWithMultipleArgument() {
+		ReflectiveHolderFactory<String> factory = new ReflectiveHolderFactory<String>(
+				TwoStringViewHolder.class, "a1", "b2");
+		ViewHolder<String> holder = factory.createViewHolderFor(null);
+		assertNotNull(holder);
+		assertEquals("a1", ((TwoStringViewHolder) holder).argument1);
+		assertEquals("b2", ((TwoStringViewHolder) holder).argument2);
+	}
+}


### PR DESCRIPTION
If you want your view holder to have other arguments passed to it besides the view, such as the context or model state you can create a factory like so:

``` java
Context context = CommentActivity.this;
Comment comment = new Comment();
ReflectiveHolderFactory<Comment> factory = new ReflectiveHolderFactory<Comment>(
                                                                               CommentHolder.class,
                                                                               context,
                                                                               comment);
```

The context and comment  will then be specified to the CommentHolder constructor that takes a `View`, `Context`, and `Comment`.
