### PR TITLE
Support primitive view holder constructor parameters

### DIFF
--- a/src/main/java/com/madgag/android/listviews/ReflectiveHolderFactory.java
+++ b/src/main/java/com/madgag/android/listviews/ReflectiveHolderFactory.java
@@ -49,7 +49,7 @@ public class ReflectiveHolderFactory<T> implements ViewHolderFactory<T> {
 				continue;
 			boolean match = true;
 			for (int i = 0; i < types.length; i++)
-				if (!params[i].isAssignableFrom(types[i])) {
+				if (!isMatch(params[i], types[i])) {
 					match = false;
 					break;
 				}
@@ -57,6 +57,27 @@ public class ReflectiveHolderFactory<T> implements ViewHolderFactory<T> {
 				return candidate;
 		}
 		return null;
+	}
+
+	private static boolean isMatch(Class<?> constructorParam, Class<?> argument) {
+		if (constructorParam.isPrimitive())
+			if (Integer.TYPE.equals(constructorParam))
+				constructorParam = Integer.class;
+			else if (Double.TYPE.equals(constructorParam))
+				constructorParam = Double.class;
+			else if (Short.TYPE.equals(constructorParam))
+				constructorParam = Short.class;
+			else if (Long.TYPE.equals(constructorParam))
+				constructorParam = Long.class;
+			else if (Float.TYPE.equals(constructorParam))
+				constructorParam = Float.class;
+			else if (Byte.TYPE.equals(constructorParam))
+				constructorParam = Byte.class;
+			else if (Character.TYPE.equals(constructorParam))
+				constructorParam = Character.class;
+			else if (Boolean.TYPE.equals(constructorParam))
+				constructorParam = Boolean.class;
+		return constructorParam.isAssignableFrom(argument);
 	}
 
 	private final Constructor<? extends ViewHolder<T>> constructor;

--- a/src/test/java/com/madgag/android/listviews/ReflectiveHolderFactoryTest.java
+++ b/src/test/java/com/madgag/android/listviews/ReflectiveHolderFactoryTest.java
@@ -57,6 +57,30 @@ public class ReflectiveHolderFactoryTest {
 		}
 	}
 
+	private static class PrimitiveIntHolder implements ViewHolder<String> {
+
+		final int argument;
+
+		public PrimitiveIntHolder(View view, int argument) {
+			this.argument = argument;
+		}
+
+		public void updateViewFor(String item) {
+		}
+	}
+
+	private static class IntegerHolder implements ViewHolder<String> {
+
+		final Integer argument;
+
+		public IntegerHolder(View view, Integer argument) {
+			this.argument = argument;
+		}
+
+		public void updateViewFor(String item) {
+		}
+	}
+
 	private static class TwoStringViewHolder implements ViewHolder<String> {
 
 		final String argument1;
@@ -136,5 +160,29 @@ public class ReflectiveHolderFactoryTest {
 		assertNotNull(holder);
 		assertEquals("a1", ((TwoStringViewHolder) holder).argument1);
 		assertEquals("b2", ((TwoStringViewHolder) holder).argument2);
+	}
+
+	/**
+	 * Create holder for class that takes an int parameter
+	 */
+	@Test
+	public void constructorWithPrimitiveInt() {
+		ReflectiveHolderFactory<String> factory = reflectiveFactoryFor(
+				PrimitiveIntHolder.class, 1);
+		ViewHolder<String> holder = factory.createViewHolderFor(null);
+		assertNotNull(holder);
+		assertEquals(1, ((PrimitiveIntHolder) holder).argument);
+	}
+
+	/**
+	 * Create holder for class that takes an {@link Integer} parameter
+	 */
+	@Test
+	public void constructorWithInteger() {
+		ReflectiveHolderFactory<String> factory = reflectiveFactoryFor(
+				IntegerHolder.class, 1);
+		ViewHolder<String> holder = factory.createViewHolderFor(null);
+		assertNotNull(holder);
+		assertEquals(Integer.valueOf(1), ((IntegerHolder) holder).argument);
 	}
 }


### PR DESCRIPTION
This requires explicitly checking for constructor parameters
being primitive and converting the primitive class type to the
non-primitive class type before checking if it is assignable from
the type given to the factory method
